### PR TITLE
Only look at changes in subdirectory

### DIFF
--- a/src/lib/cherrypickAndCreateTargetPullRequest/cherrypickAndCreateTargetPullRequest.ts
+++ b/src/lib/cherrypickAndCreateTargetPullRequest/cherrypickAndCreateTargetPullRequest.ts
@@ -47,8 +47,6 @@ export async function cherrypickAndCreateTargetPullRequest({
     commits,
   });
 
-  // TODO: backportBranch must start with a valid character
-
   const repoForkOwner = getRepoForkOwner(options);
   consoleLog(`\n${chalk.bold(`Backporting to ${JSON.stringify(target)}:`)}`);
 

--- a/src/lib/getTargetBranches.ts
+++ b/src/lib/getTargetBranches.ts
@@ -31,7 +31,10 @@ export async function getTargetBranches(
     return suggestedTargetBranches;
   }
 
-  const sourceBranch = getSourceBranchFromCommits(commits);
+  const sourceBranch =
+    commits.length === 0
+      ? options.sourceBranch
+      : getSourceBranchFromCommits(commits);
   const targetBranchChoices = getTargetBranchChoices({
     options,
     suggestedTargetBranches,

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -388,11 +388,17 @@ export const patchApply: CherrypicklikeFunction = async ({
     // Generate patch
     const { stdout: patch } = await spawnPromise(
       'git',
-      [`diff`, `${sha}^`, sha],
+      [
+        `diff`,
+        `${sha}^`,
+        sha,
+        '--',
+        path.join(cwd, target.sourceDirectory ?? ''), // include changes from source directory only
+      ],
       cwd,
     );
 
-    consoleLog(`patch: ${patch}`);
+    logger.info(`Patch: ${patch}`);
 
     if (patch.trim() === '' || !target.directories || !target.sourceDirectory) {
       throw new BackportError('Patch is empty. Nothing to apply.');


### PR DESCRIPTION
- Fixes an issue where patches would be made for files outside of the source subdirectory.
- Also filters out commits that don't touch files in subdirectory.
